### PR TITLE
feat(context): add get_context and delete_context tools

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -171,6 +171,63 @@ export class NodeRedClient {
     return NodeRedDiagnosticsSchema.parse(data);
   }
 
+  async getContext(
+    scope: 'global' | 'flow' | 'node',
+    id?: string,
+    key?: string,
+    store?: string
+  ): Promise<unknown> {
+    let url = `${this.baseUrl}/context/${scope}`;
+    if (scope !== 'global' && id) {
+      url += `/${id}`;
+    }
+    if (key) {
+      url += `/${key}`;
+    }
+    if (store) {
+      url += `?store=${encodeURIComponent(store)}`;
+    }
+
+    const response = await request(url, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+
+    if (response.statusCode !== 200) {
+      const body = await response.body.text();
+      throw new Error(`Failed to get context: ${response.statusCode}\n${body}`);
+    }
+
+    return await response.body.json();
+  }
+
+  async deleteContext(
+    scope: 'global' | 'flow' | 'node',
+    id?: string,
+    key?: string,
+    store?: string
+  ): Promise<void> {
+    let url = `${this.baseUrl}/context/${scope}`;
+    if (scope === 'global') {
+      url += `/${key}`;
+    } else {
+      url += `/${id}/${key}`;
+    }
+    if (store) {
+      url += `?store=${encodeURIComponent(store)}`;
+    }
+
+    const response = await request(url, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+
+    if (response.statusCode !== 204) {
+      const body = await response.body.text();
+      throw new Error(`Failed to delete context: ${response.statusCode}\n${body}`);
+    }
+  }
+
   async validateFlow(flowData: UpdateFlowRequest): Promise<{ valid: boolean; errors?: string[] }> {
     try {
       const errors: string[] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,9 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { NodeRedClient } from './client.js';
 import { ConfigSchema } from './schemas.js';
 import { createFlow } from './tools/create-flow.js';
+import { deleteContext } from './tools/delete-context.js';
 import { deleteFlow } from './tools/delete-flow.js';
+import { getContext } from './tools/get-context.js';
 import { getDiagnostics } from './tools/get-diagnostics.js';
 import { getFlowState } from './tools/get-flow-state.js';
 import { getFlows } from './tools/get-flows.js';
@@ -147,6 +149,61 @@ export function createServer() {
         },
       },
       {
+        name: 'get_context',
+        description:
+          'Read context store data at global, flow, or node scope. Omit key to list all keys.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scope: {
+              type: 'string',
+              enum: ['global', 'flow', 'node'],
+              description: 'Context scope to read from',
+            },
+            id: {
+              type: 'string',
+              description: 'Flow or node ID (required for flow and node scope)',
+            },
+            key: {
+              type: 'string',
+              description: 'Context key to read. Omit to list all keys.',
+            },
+            store: {
+              type: 'string',
+              description: 'Optional context store name',
+            },
+          },
+          required: ['scope'],
+        },
+      },
+      {
+        name: 'delete_context',
+        description: 'Delete a context store value at global, flow, or node scope.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scope: {
+              type: 'string',
+              enum: ['global', 'flow', 'node'],
+              description: 'Context scope to delete from',
+            },
+            id: {
+              type: 'string',
+              description: 'Flow or node ID (required for flow and node scope)',
+            },
+            key: {
+              type: 'string',
+              description: 'Context key to delete',
+            },
+            store: {
+              type: 'string',
+              description: 'Optional context store name',
+            },
+          },
+          required: ['scope', 'key'],
+        },
+      },
+      {
         name: 'get_nodes',
         description:
           'Get all installed node modules from Node-RED. Returns array of node module objects with their node sets.',
@@ -240,6 +297,10 @@ export function createServer() {
           return await getFlowState(client);
         case 'set_flow_state':
           return await setFlowState(client, request.params.arguments);
+        case 'get_context':
+          return await getContext(client, request.params.arguments);
+        case 'delete_context':
+          return await deleteContext(client, request.params.arguments);
         case 'get_nodes':
           return await getNodes(client);
         case 'install_node':

--- a/src/tools/delete-context.ts
+++ b/src/tools/delete-context.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import type { NodeRedClient } from '../client.js';
+
+const DeleteContextArgsSchema = z.object({
+  scope: z.enum(['global', 'flow', 'node']),
+  id: z.string().optional(),
+  key: z.string(),
+  store: z.string().optional(),
+});
+
+export async function deleteContext(client: NodeRedClient, args: unknown) {
+  const parsed = DeleteContextArgsSchema.parse(args);
+
+  if ((parsed.scope === 'flow' || parsed.scope === 'node') && !parsed.id) {
+    throw new Error(`id is required when scope is "${parsed.scope}"`);
+  }
+
+  await client.deleteContext(parsed.scope, parsed.id, parsed.key, parsed.store);
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            message: `Deleted context key "${parsed.key}" from ${parsed.scope} scope`,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/src/tools/get-context.ts
+++ b/src/tools/get-context.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { NodeRedClient } from '../client.js';
+
+const GetContextArgsSchema = z.object({
+  scope: z.enum(['global', 'flow', 'node']),
+  id: z.string().optional(),
+  key: z.string().optional(),
+  store: z.string().optional(),
+});
+
+export async function getContext(client: NodeRedClient, args: unknown) {
+  const parsed = GetContextArgsSchema.parse(args);
+
+  if ((parsed.scope === 'flow' || parsed.scope === 'node') && !parsed.id) {
+    throw new Error(`id is required when scope is "${parsed.scope}"`);
+  }
+
+  const result = await client.getContext(parsed.scope, parsed.id, parsed.key, parsed.store);
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- Add `getContext()` and `deleteContext()` methods to `NodeRedClient` for interacting with Node-RED context store API
- Create `get-context.ts` and `delete-context.ts` tool handlers with Zod-based arg validation
- Register `get_context` and `delete_context` tools in MCP server with proper input schemas
- Add comprehensive tests for both client methods and tool handlers (20 new tests)
- Add `.tailscale` to vitest exclude to prevent EACCES permission errors

## Context Store API Coverage

| Endpoint | Method | Tool |
|----------|--------|------|
| `/context/global` | GET | `get_context` |
| `/context/global/:key` | GET | `get_context` |
| `/context/flow/:id` | GET | `get_context` |
| `/context/flow/:id/:key` | GET | `get_context` |
| `/context/node/:id/:key` | GET | `get_context` |
| `/context/global/:key` | DELETE | `delete_context` |
| `/context/flow/:id/:key` | DELETE | `delete_context` |
| `/context/node/:id/:key` | DELETE | `delete_context` |

Optional `?store=` query parameter supported on all endpoints.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 49 tests pass (`npx vitest --run`)
- [x] Lint passes (`npm run lint`)
- [x] Client tests cover all scope variants (global, flow, node) for get and delete
- [x] Client tests cover store query parameter, error handling
- [x] Tool handler tests cover arg validation (id required for flow/node scope)
- [x] Tool handler tests cover invalid scope rejection