### PR TITLE
feat(runtime): add get_settings and get_diagnostics tools

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,10 +4,18 @@ import type {
   Config,
   FlowState,
   NodeModule,
+  NodeRedDiagnostics,
   NodeRedFlowsResponse,
+  NodeRedSettings,
   UpdateFlowRequest,
 } from './schemas.js';
-import { FlowStateSchema, NodeModuleSchema, NodeRedFlowsResponseSchema } from './schemas.js';
+import {
+  FlowStateSchema,
+  NodeModuleSchema,
+  NodeRedDiagnosticsSchema,
+  NodeRedFlowsResponseSchema,
+  NodeRedSettingsSchema,
+} from './schemas.js';
 
 export class NodeRedClient {
   private readonly baseUrl: string;
@@ -131,6 +139,36 @@ export class NodeRedClient {
 
     const data = await response.body.json();
     return FlowStateSchema.parse(data);
+  }
+
+  async getSettings(): Promise<NodeRedSettings> {
+    const response = await request(`${this.baseUrl}/settings`, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+
+    if (response.statusCode !== 200) {
+      const body = await response.body.text();
+      throw new Error(`Failed to get settings: ${response.statusCode}\n${body}`);
+    }
+
+    const data = await response.body.json();
+    return NodeRedSettingsSchema.parse(data);
+  }
+
+  async getDiagnostics(): Promise<NodeRedDiagnostics> {
+    const response = await request(`${this.baseUrl}/diagnostics`, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+
+    if (response.statusCode !== 200) {
+      const body = await response.body.text();
+      throw new Error(`Failed to get diagnostics: ${response.statusCode}\n${body}`);
+    }
+
+    const data = await response.body.json();
+    return NodeRedDiagnosticsSchema.parse(data);
   }
 
   async validateFlow(flowData: UpdateFlowRequest): Promise<{ valid: boolean; errors?: string[] }> {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -71,6 +71,31 @@ export const NodeModuleSchema = z
   })
   .passthrough();
 
+export const NodeRedSettingsSchema = z
+  .object({
+    httpNodeRoot: z.string().optional(),
+    version: z.string().optional(),
+    user: z
+      .object({
+        username: z.string(),
+        permissions: z.string(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export const NodeRedDiagnosticsSchema = z
+  .object({
+    report: z.string().optional(),
+    scope: z.string().optional(),
+    nodejs: z.unknown().optional(),
+    os: z.unknown().optional(),
+    runtime: z.unknown().optional(),
+    modules: z.unknown().optional(),
+    settings: z.unknown().optional(),
+  })
+  .passthrough();
+
 export const ConfigSchema = z.object({
   nodeRedUrl: z.string().url(),
   nodeRedToken: z.string().optional(),
@@ -85,4 +110,6 @@ export type UpdateFlowRequest = z.infer<typeof UpdateFlowRequestSchema>;
 export type FlowState = z.infer<typeof FlowStateSchema>;
 export type NodeSet = z.infer<typeof NodeSetSchema>;
 export type NodeModule = z.infer<typeof NodeModuleSchema>;
+export type NodeRedSettings = z.infer<typeof NodeRedSettingsSchema>;
+export type NodeRedDiagnostics = z.infer<typeof NodeRedDiagnosticsSchema>;
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,11 @@ import { NodeRedClient } from './client.js';
 import { ConfigSchema } from './schemas.js';
 import { createFlow } from './tools/create-flow.js';
 import { deleteFlow } from './tools/delete-flow.js';
+import { getDiagnostics } from './tools/get-diagnostics.js';
 import { getFlowState } from './tools/get-flow-state.js';
 import { getFlows } from './tools/get-flows.js';
 import { getNodes } from './tools/get-nodes.js';
+import { getSettings } from './tools/get-settings.js';
 import { installNode } from './tools/install-node.js';
 import { removeNodeModule } from './tools/remove-node-module.js';
 import { setFlowState } from './tools/set-flow-state.js';
@@ -200,6 +202,24 @@ export function createServer() {
           required: ['module'],
         },
       },
+      {
+        name: 'get_settings',
+        description:
+          'Get the runtime settings of the Node-RED instance. Returns server configuration including version, httpNodeRoot, and user info.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'get_diagnostics',
+        description:
+          'Get diagnostic information about the Node-RED runtime. Returns system info including Node.js version, OS details, and memory usage.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
     ],
   }));
 
@@ -228,6 +248,10 @@ export function createServer() {
           return await setNodeModuleState(client, request.params.arguments);
         case 'remove_node_module':
           return await removeNodeModule(client, request.params.arguments);
+        case 'get_settings':
+          return await getSettings(client);
+        case 'get_diagnostics':
+          return await getDiagnostics(client);
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
       }

--- a/src/tools/get-diagnostics.ts
+++ b/src/tools/get-diagnostics.ts
@@ -1,0 +1,13 @@
+import type { NodeRedClient } from '../client.js';
+
+export async function getDiagnostics(client: NodeRedClient) {
+  const result = await client.getDiagnostics();
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/src/tools/get-settings.ts
+++ b/src/tools/get-settings.ts
@@ -1,0 +1,13 @@
+import type { NodeRedClient } from '../client.js';
+
+export async function getSettings(client: NodeRedClient) {
+  const result = await client.getSettings();
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/tests/client-runtime.test.ts
+++ b/tests/client-runtime.test.ts
@@ -1,0 +1,111 @@
+import { request } from 'undici';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeRedClient } from '../src/client.js';
+import type { Config } from '../src/schemas.js';
+
+vi.mock('undici');
+
+describe('NodeRedClient - Runtime Info', () => {
+  let client: NodeRedClient;
+  const mockConfig: Config = {
+    nodeRedUrl: 'http://localhost:1880',
+    nodeRedToken: 'test-token',
+  };
+
+  beforeEach(() => {
+    client = new NodeRedClient(mockConfig);
+    vi.clearAllMocks();
+  });
+
+  describe('getSettings', () => {
+    it('should fetch settings successfully', async () => {
+      const mockSettings = {
+        httpNodeRoot: '/',
+        version: '3.1.0',
+        user: { username: 'admin', permissions: '*' },
+        editorTheme: { projects: { enabled: true } },
+      };
+
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 200,
+        body: { json: vi.fn().mockResolvedValue(mockSettings), text: vi.fn() },
+      } as any);
+
+      const result = await client.getSettings();
+      expect(result).toEqual(mockSettings);
+      expect(request).toHaveBeenCalledWith('http://localhost:1880/settings', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Node-RED-API-Version': 'v2',
+          Authorization: 'Bearer test-token',
+        },
+      });
+    });
+
+    it('should throw error on failed request', async () => {
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 500,
+        body: { text: vi.fn().mockResolvedValue('Internal Server Error') },
+      } as any);
+      await expect(client.getSettings()).rejects.toThrow('Failed to get settings: 500');
+    });
+
+    it('should handle settings without optional fields', async () => {
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 200,
+        body: { json: vi.fn().mockResolvedValue({}), text: vi.fn() },
+      } as any);
+      const result = await client.getSettings();
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getDiagnostics', () => {
+    it('should fetch diagnostics successfully', async () => {
+      const mockDiagnostics = {
+        report: 'diagnostics',
+        scope: 'admin',
+        nodejs: { version: 'v20.10.0' },
+        os: { type: 'Linux', release: '6.1.0' },
+        runtime: { version: '3.1.0' },
+        modules: {},
+        settings: {},
+      };
+
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 200,
+        body: { json: vi.fn().mockResolvedValue(mockDiagnostics), text: vi.fn() },
+      } as any);
+
+      const result = await client.getDiagnostics();
+      expect(result).toEqual(mockDiagnostics);
+      expect(request).toHaveBeenCalledWith('http://localhost:1880/diagnostics', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Node-RED-API-Version': 'v2',
+          Authorization: 'Bearer test-token',
+        },
+      });
+    });
+
+    it('should throw error on failed request', async () => {
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 403,
+        body: { text: vi.fn().mockResolvedValue('Forbidden') },
+      } as any);
+      await expect(client.getDiagnostics()).rejects.toThrow('Failed to get diagnostics: 403');
+    });
+
+    it('should handle diagnostics with extra fields', async () => {
+      const diagnosticsWithExtras = { report: 'diagnostics', customField: 'extra data' };
+      vi.mocked(request).mockResolvedValue({
+        statusCode: 200,
+        body: { json: vi.fn().mockResolvedValue(diagnosticsWithExtras), text: vi.fn() },
+      } as any);
+      const result = await client.getDiagnostics();
+      expect(result).toEqual(diagnosticsWithExtras);
+    });
+  });
+});

--- a/tests/tools-runtime.test.ts
+++ b/tests/tools-runtime.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NodeRedClient } from '../src/client.js';
+import { getDiagnostics } from '../src/tools/get-diagnostics.js';
+import { getSettings } from '../src/tools/get-settings.js';
+
+describe('Runtime Info Tool Handlers', () => {
+  let mockClient: NodeRedClient;
+
+  beforeEach(() => {
+    mockClient = {
+      getSettings: vi.fn(),
+      getDiagnostics: vi.fn(),
+    } as any;
+  });
+
+  describe('getSettings', () => {
+    it('should return formatted settings', async () => {
+      const mockSettingsData = {
+        httpNodeRoot: '/',
+        version: '3.1.0',
+        user: { username: 'admin', permissions: '*' },
+      };
+      vi.mocked(mockClient.getSettings).mockResolvedValue(mockSettingsData);
+      const result = await getSettings(mockClient);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(JSON.parse(result.content[0].text)).toEqual(mockSettingsData);
+    });
+
+    it('should handle empty settings', async () => {
+      vi.mocked(mockClient.getSettings).mockResolvedValue({});
+      const result = await getSettings(mockClient);
+      expect(result.content).toHaveLength(1);
+      expect(JSON.parse(result.content[0].text)).toEqual({});
+    });
+  });
+
+  describe('getDiagnostics', () => {
+    it('should return formatted diagnostics', async () => {
+      const mockDiagnosticsData = {
+        report: 'diagnostics',
+        scope: 'admin',
+        nodejs: { version: 'v20.10.0' },
+        os: { type: 'Linux' },
+      };
+      vi.mocked(mockClient.getDiagnostics).mockResolvedValue(mockDiagnosticsData);
+      const result = await getDiagnostics(mockClient);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(JSON.parse(result.content[0].text)).toEqual(mockDiagnosticsData);
+    });
+
+    it('should handle minimal diagnostics', async () => {
+      vi.mocked(mockClient.getDiagnostics).mockResolvedValue({});
+      const result = await getDiagnostics(mockClient);
+      expect(result.content).toHaveLength(1);
+      expect(JSON.parse(result.content[0].text)).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `get_settings` tool to retrieve Node-RED runtime settings (GET /settings)
- Add `get_diagnostics` tool to retrieve Node-RED runtime diagnostics (GET /diagnostics)

## Changes
- **Schemas**: Added `NodeRedSettingsSchema` and `NodeRedDiagnosticsSchema` with `.passthrough()` for extensibility
- **Client**: Added `getSettings()` and `getDiagnostics()` methods to `NodeRedClient`
- **Tools**: Created `src/tools/get-settings.ts` and `src/tools/get-diagnostics.ts` handlers
- **Server**: Registered both tools in the MCP server with proper descriptions and empty input schemas
- **Tests**: Added 10 new tests covering client HTTP methods and tool handler responses

## Test plan
- [x] All 32 tests pass (including 10 new ones)
- [x] Lint clean
- [x] Build clean
- [ ] CI checks pass