### PR TITLE
docs: update documentation for all 17 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node-RED MCP Server
 
-MCP server for Node-RED workflow management. Provides AI assistants with tools to read, create, and update your Node-RED flows safely through the Admin API v2.
+MCP server for Node-RED workflow management. Provides AI assistants with 17 tools to manage flows, node modules, context stores, and runtime settings through the Node-RED Admin API v2.
 
 ## Installation
 
@@ -101,10 +101,34 @@ Note: No `NODE_RED_TOKEN` needed - credentials are in the URL.
 
 ## Features
 
+### Flow Management
 - **get_flows**: Retrieve all flows from your Node-RED instance
 - **create_flow**: Create new flows via POST /flow
-- **update_flow**: Update individual flows via PUT /flow/:id
+- **update_flow**: Update individual flows safely via PUT /flow/:id
 - **validate_flow**: Validate flow configuration without deploying
+- **delete_flow**: Delete a flow and all its nodes by ID
+
+### Runtime Control
+- **get_flow_state**: Get runtime state of flows (started/stopped)
+- **set_flow_state**: Start or stop all flows in the runtime
+
+### Node Module Management
+- **get_nodes**: List all installed node modules with versions and status
+- **install_node**: Install a node module from the npm registry
+- **set_node_module_state**: Enable or disable an installed node module
+- **remove_node_module**: Uninstall a node module from Node-RED
+
+### Context Store
+- **get_context**: Read context data at global, flow, or node scope
+- **delete_context**: Delete context values at any scope
+
+### Runtime Info
+- **get_settings**: Get Node-RED runtime settings including version
+- **get_diagnostics**: Get system diagnostics (Node.js, OS, memory)
+
+### Node Interaction
+- **trigger_inject**: Trigger an inject node (same as clicking the button)
+- **set_debug_state**: Enable or disable a debug node's output
 
 ## Usage
 
@@ -123,7 +147,27 @@ Update flow "flow1" to change its label to "New Name"
 ```
 
 ```
-Validate this flow configuration: {...}
+Delete the flow with ID "flow1"
+```
+
+```
+What node modules are installed?
+```
+
+```
+Install the node-red-contrib-mqtt module
+```
+
+```
+Trigger the inject node to test my flow
+```
+
+```
+Show me the global context data
+```
+
+```
+Get the Node-RED runtime settings and version
 ```
 
 ## Safety Features
@@ -132,6 +176,8 @@ Validate this flow configuration: {...}
 - **No accidental deletions**: Other flows remain completely untouched
 - **Validation**: All flow configurations are validated before sending to Node-RED
 - **Read-only by default**: Only modifies flows when explicitly requested
+- **Module management guards**: Core modules cannot be removed; enable/disable is reversible
+- **Scoped context operations**: Context reads and deletes are scoped to specific keys
 
 ## Development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,30 +37,64 @@ npm run format
 
 ## Node-RED Admin API v2
 
-The server uses Admin API v2 endpoints:
+The server uses Admin API v2 endpoints. All requests include `Node-RED-API-Version: v2` and `Authorization` headers.
 
-### GET /flows
-- Returns all flows: `{rev: "...", flows: [...]}`
-- Headers: `Node-RED-API-Version: v2`, `Authorization`
+### Flow Management
 
-### POST /flow
-- Creates a new flow
-- Request: `{id, label, nodes: [], configs: []}`
-- Response: 200 or 204 with `{id: "..."}` in body
-- Flow ID is optional - auto-generated if not provided
+**GET /flows** - Returns all flows: `{rev: "...", flows: [...]}`
 
-### PUT /flow/:id
-- Updates a single flow by ID
-- Request: `{id, label, nodes: [], configs: []}`
-- Response: 204 with `{id: "..."}` in body
-- Only affects the specified flow, all other flows remain untouched
+**POST /flow** - Creates a new flow. Request: `{id, label, nodes: [], configs: []}`. Response: 200/204 with `{id: "..."}`.
+
+**PUT /flow/:id** - Updates a single flow by ID. Only affects the specified flow. Request: `{id, label, nodes: [], configs: []}`. Response: 204 with `{id: "..."}`.
+
+**DELETE /flow/:id** - Deletes a flow and all its nodes. Response: 204.
+
+### Runtime Control
+
+**GET /flows/state** - Returns runtime state: `{state: "start"|"stop"}`. Requires `runtimeState.enabled: true`.
+
+**POST /flows/state** - Start or stop flows. Request: `{state: "start"|"stop"}`.
+
+### Node Module Management
+
+**GET /nodes** - Returns array of installed node module objects.
+
+**POST /nodes** - Install a module from npm. Request: `{module: "node-red-contrib-foo"}`.
+
+**PUT /nodes/:module** - Enable/disable a module. Request: `{enabled: true|false}`.
+
+**DELETE /nodes/:module** - Remove an installed module. Response: 204.
+
+### Context Store
+
+**GET /context/global[/:key]** - Read global context keys or a specific value.
+
+**GET /context/flow/:id[/:key]** - Read flow context keys or a specific value.
+
+**GET /context/node/:id[/:key]** - Read node context keys or a specific value.
+
+**DELETE /context/:scope/:id/:key** - Delete a context value. Response: 204.
+
+### Runtime Info
+
+**GET /settings** - Returns runtime settings: `{httpNodeRoot, version, user, ...}`.
+
+**GET /diagnostics** - Returns diagnostic info: `{nodejs, os, runtime, modules, ...}`.
+
+### Node Interaction
+
+**POST /inject/:id** - Trigger an inject node to fire.
+
+**POST /debug/:id/:state** - Enable or disable a debug node (state = "enable"|"disable").
 
 ## Testing
 
-Tests use vitest with mocked `undici` requests. Each component has dedicated test file:
-- `tests/client.test.ts` - HTTP client + auth modes
-- `tests/tools.test.ts` - Tool handlers
-- `tests/server.test.ts` - MCP server setup
+Tests use vitest with mocked `undici` requests. Each component has dedicated test files:
+- `tests/client.test.ts` - HTTP client + auth modes + flow/node/context/runtime methods
+- `tests/client-runtime.test.ts` - Runtime and node management client methods
+- `tests/tools.test.ts` - Tool handlers for all 17 tools
+- `tests/tools-runtime.test.ts` - Runtime and node management tool handlers
+- `tests/server.test.ts` - MCP server setup and tool listing
 
 ## Error Handling
 

--- a/docs/specs/0001-complete-node-red-admin-api.md
+++ b/docs/specs/0001-complete-node-red-admin-api.md
@@ -356,48 +356,48 @@ Estimated new tests: ~60-80 test cases across the three test files.
   - [x] Add client tests for `deleteFlow` (success, 404)
   - [x] Add tool handler tests for `delete_flow`
   - [x] Update server test to verify new tool appears in tool listing
-- [ ] Add flow state tools: `get_flow_state`, `set_flow_state`
-  - [ ] Add `FlowStateSchema` to `src/schemas.ts`
-  - [ ] Add `getFlowState()` and `setFlowState(state)` methods to `src/client.ts`
-  - [ ] Create `src/tools/get-flow-state.ts` and `src/tools/set-flow-state.ts`
-  - [ ] Register both tools in `src/server.ts`
-  - [ ] Add client tests (success, runtimeState-disabled 400 error)
-  - [ ] Add tool handler tests
-- [ ] Add node module management tools: `get_nodes`, `install_node`, `set_node_module_state`, `remove_node_module`
-  - [ ] Add `NodeSetSchema`, `NodeModuleSchema` to `src/schemas.ts`
-  - [ ] Add `getNodes()`, `installNode(module)`, `setNodeModuleState(module, enabled)`, `removeNodeModule(module)` to `src/client.ts`
-  - [ ] Create `src/tools/get-nodes.ts`
-  - [ ] Create `src/tools/install-node.ts`
-  - [ ] Create `src/tools/set-node-module-state.ts`
-  - [ ] Create `src/tools/remove-node-module.ts`
-  - [ ] Register all 4 tools in `src/server.ts`
-  - [ ] Add client tests for all 4 methods (success, 404, 400 errors)
-  - [ ] Add tool handler tests for all 4 tools
-- [ ] Add context store tools: `get_context`, `delete_context`
-  - [ ] Add `getContext(scope, id?, key?, store?)` and `deleteContext(scope, id?, key, store?)` to `src/client.ts`
-  - [ ] Create `src/tools/get-context.ts` with scope/id/key arg validation
-  - [ ] Create `src/tools/delete-context.ts` with scope/id/key arg validation
-  - [ ] Register both tools in `src/server.ts`
-  - [ ] Add client tests for all scope variants (global, global/key, flow/:id, flow/:id/key, node/:id, node/:id/key) and delete variants
-  - [ ] Add tool handler tests including arg validation (id required for flow/node scope)
-- [ ] Add runtime info tools: `get_settings`, `get_diagnostics`
-  - [ ] Add `NodeRedSettingsSchema` and `NodeRedDiagnosticsSchema` to `src/schemas.ts`
-  - [ ] Add `getSettings()` and `getDiagnostics()` to `src/client.ts`
-  - [ ] Create `src/tools/get-settings.ts` and `src/tools/get-diagnostics.ts`
-  - [ ] Register both tools in `src/server.ts`
-  - [ ] Add client and tool handler tests
-- [ ] Add node-specific trigger tools: `trigger_inject`, `set_debug_state`
-  - [ ] Add `triggerInject(nodeId)` and `setDebugNodeState(nodeId, enabled)` to `src/client.ts`
-  - [ ] Create `src/tools/trigger-inject.ts`
-  - [ ] Create `src/tools/set-debug-state.ts`
-  - [ ] Register both tools in `src/server.ts`
-  - [ ] Add client tests (success, 404 not found, 500 node error for inject)
-  - [ ] Add tool handler tests
-- [ ] Update documentation and CLAUDE.md
-  - [ ] Update CLAUDE.md project overview to reflect new tool count
-  - [ ] Update CLAUDE.md architecture section with new tools and API endpoints
-  - [ ] Update CLAUDE.md "ALWAYS Use MCP Tools" section with full tool list
-  - [ ] Update README.md with new tool descriptions and usage examples
+- [x] Add flow state tools: `get_flow_state`, `set_flow_state`
+  - [x] Add `FlowStateSchema` to `src/schemas.ts`
+  - [x] Add `getFlowState()` and `setFlowState(state)` methods to `src/client.ts`
+  - [x] Create `src/tools/get-flow-state.ts` and `src/tools/set-flow-state.ts`
+  - [x] Register both tools in `src/server.ts`
+  - [x] Add client tests (success, runtimeState-disabled 400 error)
+  - [x] Add tool handler tests
+- [x] Add node module management tools: `get_nodes`, `install_node`, `set_node_module_state`, `remove_node_module`
+  - [x] Add `NodeSetSchema`, `NodeModuleSchema` to `src/schemas.ts`
+  - [x] Add `getNodes()`, `installNode(module)`, `setNodeModuleState(module, enabled)`, `removeNodeModule(module)` to `src/client.ts`
+  - [x] Create `src/tools/get-nodes.ts`
+  - [x] Create `src/tools/install-node.ts`
+  - [x] Create `src/tools/set-node-module-state.ts`
+  - [x] Create `src/tools/remove-node-module.ts`
+  - [x] Register all 4 tools in `src/server.ts`
+  - [x] Add client tests for all 4 methods (success, 404, 400 errors)
+  - [x] Add tool handler tests for all 4 tools
+- [x] Add context store tools: `get_context`, `delete_context`
+  - [x] Add `getContext(scope, id?, key?, store?)` and `deleteContext(scope, id?, key, store?)` to `src/client.ts`
+  - [x] Create `src/tools/get-context.ts` with scope/id/key arg validation
+  - [x] Create `src/tools/delete-context.ts` with scope/id/key arg validation
+  - [x] Register both tools in `src/server.ts`
+  - [x] Add client tests for all scope variants (global, global/key, flow/:id, flow/:id/key, node/:id, node/:id/key) and delete variants
+  - [x] Add tool handler tests including arg validation (id required for flow/node scope)
+- [x] Add runtime info tools: `get_settings`, `get_diagnostics`
+  - [x] Add `NodeRedSettingsSchema` and `NodeRedDiagnosticsSchema` to `src/schemas.ts`
+  - [x] Add `getSettings()` and `getDiagnostics()` to `src/client.ts`
+  - [x] Create `src/tools/get-settings.ts` and `src/tools/get-diagnostics.ts`
+  - [x] Register both tools in `src/server.ts`
+  - [x] Add client and tool handler tests
+- [x] Add node-specific trigger tools: `trigger_inject`, `set_debug_state`
+  - [x] Add `triggerInject(nodeId)` and `setDebugNodeState(nodeId, enabled)` to `src/client.ts`
+  - [x] Create `src/tools/trigger-inject.ts`
+  - [x] Create `src/tools/set-debug-state.ts`
+  - [x] Register both tools in `src/server.ts`
+  - [x] Add client tests (success, 404 not found, 500 node error for inject)
+  - [x] Add tool handler tests
+- [x] Update documentation and CLAUDE.md
+  - [x] Update CLAUDE.md project overview to reflect new tool count
+  - [x] Update CLAUDE.md architecture section with new tools and API endpoints
+  - [x] Update CLAUDE.md "ALWAYS Use MCP Tools" section with full tool list
+  - [x] Update README.md with new tool descriptions and usage examples
 
 ## Open Questions
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=20"
   },
   "lint-staged": {
-    "*.{js,ts,json,md}": [
+    "*.{js,ts,json}": [
       "biome format --write --files-ignore-unknown=true",
       "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true"
     ]


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md, README.md, and development.md to reflect all 17 MCP tools (was 4)
- Added complete Node-RED Admin API v2 endpoint reference organized by category
- Marked all tasks complete in docs/specs/0001-complete-node-red-admin-api.md
- Fixed lint-staged config to exclude .md files from biome

## Test plan
- [x] All CI checks pass
- [x] Documentation accurately reflects implemented tools
- [x] Spec file shows all tasks complete